### PR TITLE
Misc. accessibility tweaks

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <div class="footer__top">
+  <div class="footer__top" aria-hidden="true">
     <button id="js-scroll-top">
       <svg xmlns="http://www.w3.org/2000/svg" width="10" height="6">
         <path d="M0 5l5-5"/>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,12 +1,12 @@
 <a href="#content" tabindex="0" class="accessibility-aid">Skip to content</a>
 
 <header class="header">
-  <a class="header__logo" href="/">
-    <p class="header__logo__title">{{ site.title }}</p>
-    <p class="header__logo__subtitle">{{ site.description }}</p>
+  <a class="header__logo" href="/" role="logo">
+    <div class="header__logo__title">{{ site.title }}</div>
+    <div class="header__logo__subtitle">{{ site.description }}</div>
   </a>
 
-  <nav class="header__nav">
+  <div class="header__nav">
     <a id="js-mobile-menu-trigger" class="header__nav__icon" href="#">
       <span class="header__nav__icon__text">Menu</span>
 
@@ -17,7 +17,7 @@
       </div>
     </a>
 
-    <div id="js-mobile-menu" class="header__nav__menu">
+    <nav id="js-mobile-menu" class="header__nav__menu">
       {% for link in site.data.nav %}
         {% assign current = nil %}
         {% if page.url contains link.url %}
@@ -26,6 +26,6 @@
 
         <a class="header__nav__menu__item {{ current }}" href="{{ link.url }}">{{ link.title }}</a>
       {% endfor %}
-    </div>
-  </nav>
+    </nav>
+  </div>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,13 +5,13 @@
   <body>
     {% include header.html %}
 
-    <div id="content" class="page-content">
+    <main id="content" class="page-content">
       <header class="post__header">
         <h1>{{ page.title }}</h1>
       </header>
 
       {{ content }}
-    </div>
+    </main>
 
     {% include footer.html %}
   </body>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,7 +5,7 @@
   <body>
     {% include header.html %}
 
-    <div id="content" class="page-content">
+    <main id="content" class="page-content">
       <div class="post">
         <header class="post__header">
           <h1>{{ page.title }}</h1>
@@ -21,7 +21,7 @@
           {{ content }}
         </article>
       </div>
-    </div>
+    </main>
 
     {% include footer.html %}
   </body>

--- a/static/css/_layout.scss
+++ b/static/css/_layout.scss
@@ -72,6 +72,11 @@
         background-color: $brand;
       }
     }
+
+    &::after {
+      content: ': ';
+      opacity: 0;
+    }
   }
 
   .header__logo__subtitle {


### PR DESCRIPTION
- Hide "Back to top" button from screen readers (seems unnecessary for the jump in navigation, not to mention it doesn't actually change the focus)
- Added a (visibly hidden) colon after the logo's title so that it flows better when read out
- Use `nav` properly so that the number of options read out is correct (i.e. 9 instead of 1)
- Use `main` for the main content
